### PR TITLE
Fix backtics in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ export function radEventListener<
 }
 ```
 
-So that's where we are now. You can copy the code above into your project or just install the package. The whole thing is 184 bytes gzipped. Importing individual functions is going to be even smaller (`on` 101 bytes, ` radEventListener`` 105 bytes,  `rad` 146 bytes).
+So that's where we are now. You can copy the code above into your project or just install the package. The whole thing is 184 bytes gzipped. Importing individual functions is going to be even smaller (`on` 101 bytes, `radEventListener` 105 bytes,  `rad` 146 bytes).
 
 ## Another sane type-safe alternative
 


### PR DESCRIPTION
Thanks for this util! I noticed unmatched code escape backtics in the README, here's a PR.